### PR TITLE
Improve Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ export EMAIL_FROM=test@example.org
 export EMAIL_USER=””
 export EMAIL_PASSWORD=””
 ```
+You can access the MailHog UI at `localhost:8025`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,13 +66,13 @@ func sendEmail(to, subject, body string) error {
 
 	port, err := strconv.Atoi(strPort)
 	if err != nil {
-		return err
+		return fmt.Errorf("error reading email server port %w", err)
 	}
 
 	d := gomail.NewDialer(host, port, user, password)
 	s, err := d.Dial()
 	if err != nil {
-		return err
+		return fmt.Errorf("error dialing email server %w", err)
 	}
 
 	m := gomail.NewMessage()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -34,7 +34,7 @@ func TestGenerateSecretSantaMachesReturnsAppropriateLenghtOfMatchPairs(t *testin
 	var payload []Data
 	payload = append(payload, Data{Name: "A", Email: "testa@test.org"})
 	payload = append(payload, Data{Name: "B", Email: "testb@test.org"})
-	payload = append(payload, Data{Name: "C", Email: "testb@test.org"})
+	payload = append(payload, Data{Name: "C", Email: "testc@test.org"})
 
 	matches := generateSecretSantaMatches(payload)
 
@@ -47,7 +47,7 @@ func TestCircularMatchingAlgorithmReturnsExpectedMatchPairs(t *testing.T) {
 	var payload []Data
 	payload = append(payload, Data{Name: "A", Email: "testa@test.org"})
 	payload = append(payload, Data{Name: "B", Email: "testb@test.org"})
-	payload = append(payload, Data{Name: "C", Email: "testb@test.org"})
+	payload = append(payload, Data{Name: "C", Email: "testc@test.org"})
 
 	var expected []MatchPair
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.21.4
 
 require github.com/spf13/cobra v1.8.0
 
+require github.com/pkg/errors v0.9.1 // indirect
+
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=


### PR DESCRIPTION
In this PR we improve the error handling mechanism by using [RunE](https://pkg.go.dev/github.com/spf13/cobra#Command.RunE) that returns an error instead of [Run](https://pkg.go.dev/github.com/spf13/cobra#Command.Run) , and delegating the error handling to the caller instead of `log.Fatal()` every time there is an error in the code.