### PR TITLE
Change args to flags, support custom html template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SSMG 
+# SSMG
 
 ![CI](https://github.com/kkoutsilis/SSMG/actions/workflows/ci.yml/badge.svg)
 
@@ -9,14 +9,14 @@ SSMG (Secret Santa Match Generator) is a simple CLI tool written in Go. It reads
 Picture this: my friends and I, spread across the globe, were scheming up a festive get-together complete with a sprinkle of Secret Santa enchantment. Now, the catch? Our scattered geography made the classic match-making puzzle a bit tricky. Sure, there are online platforms for such scenarios, but most demanded user accounts—a hoop I'd rather not jump through. And then there's the whole sharing-emails-with-apps deal, not my cup of cocoa. So, cue my weekend project: a sleek CLI tool tailored to weave our Secret Santa magic, no strings attached. Here's to coding our way to holiday cheer! 🌐🎄✨
 
 **Disclaimer**  
-I am not so familiar with GO so the code probably needs cleaning and improvements, but hey, it works! 
+I am not so familiar with GO so the code probably needs cleaning and improvements, but hey, it works!
 
 ### Usage
 
+To use SSMG, you need to have go installed, clone the repo locally, provide a JSON file containing the participant data and some environment variables to be used to send the emails.
 
-To use SSMG, you need to have go installed, clone the repo locally, provide a JSON file containing the participant data and some environmental variables to be used to send the emails.
+#### Environment Variables
 
-#### Environmental Variables 
 - `EMAIL_HOST`: The email host, for example `smtp.gmail.com` for gmail.
 
 - `EMAIL_PORT`: The email port, tipically `583` for smtp.
@@ -27,40 +27,43 @@ To use SSMG, you need to have go installed, clone the repo locally, provide a JS
 
 - `EMAIL_PASSWORD`: The passwowrd for the given email account.
 
-**Note**: Gmail does not allow plain password login and instead uses app passwords, which is more secure as well. You can learn how to create and use app passwords [here](https://support.google.com/accounts/answer/185833). 
+**Note**: Gmail does not allow plain password login and instead uses app passwords, which is more secure as well. You can learn how to create and use app passwords [here](https://support.google.com/accounts/answer/185833).
 
 #### Input File Format
 
 ```json
 [
-    {
-      "name": "participant1",
-      "email": "participant@test.com",
-    },
-    {
-      "name": "participant2",
-      "email": "participant2@test.com"
-    }
+  {
+    "name": "participant1",
+    "email": "participant@test.com"
+  },
+  {
+    "name": "participant2",
+    "email": "participant2@test.com"
+  }
 ]
-
 ```
 
 #### Run
+
 ```bash
-go run main.go --file my_data.json   
+go run main.go --file my_data.json
 ```
+
 or by using the binary
+
 ```bash
  go build --ldflags "-s -w" ssmg
 ./ssmg --file my_data.json
 ```
-**Note**: If `file` flag is not provided, the program will default to data.json.
 
+**Note**: If `file` flag is not provided, the program will default to data.json.
 
 ### Testing Emails
 
 There is a docker compose file that spins up a [MailHog](https://github.com/mailhog/MailHog) service that can be used for testing the emails.
-Simply `docker compose up` to use the testing (MailHoghttps://github.com/mailhog/MailHog) service and set the environmentat variables to 
+Simply `docker compose up` to use the testing (MailHoghttps://github.com/mailhog/MailHog) service and set the environment variables to
+
 ```bash
 export EMAIL_HOST=localhost
 export EMAIL_PORT=1025
@@ -68,4 +71,5 @@ export EMAIL_FROM=test@example.org
 export EMAIL_USER=””
 export EMAIL_PASSWORD=””
 ```
+
 You can access the MailHog UI at `localhost:8025`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # SSMG 
 
 ![CI](https://github.com/kkoutsilis/SSMG/actions/workflows/ci.yml/badge.svg)
@@ -47,16 +46,21 @@ To use SSMG, you need to have go installed, clone the repo locally, provide a JS
 ```
 
 #### Run
+```bash
+go run main.go --file my_data.json   
 ```
-go run main.go my_data.json   
+or by using the binary
+```bash
+ go build --ldflags "-s -w" ssmg
+./ssmg --file my_data.json
 ```
-**Note**: If no filename is provided, the program will default to data.json.
+**Note**: If `file` flag is not provided, the program will default to data.json.
 
 
 ### Testing Emails
 
-There is a docker compose file that spins up a MailHog service that can be used for testing the emails.
-Simply `docker compose up` to use the testing MailHog service and set the environmentat variables to 
+There is a docker compose file that spins up a [MailHog](https://github.com/mailhog/MailHog) service that can be used for testing the emails.
+Simply `docker compose up` to use the testing (MailHoghttps://github.com/mailhog/MailHog) service and set the environmentat variables to 
 ```bash
 export EMAIL_HOST=localhost
 export EMAIL_PORT=1025

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,22 +214,22 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	_, ok := os.LookupEnv("EMAIL_HOST")
 	if !ok {
-		fmt.Printf("EMAIL_HOST environmental variable is not set")
+		fmt.Printf("EMAIL_HOST environment variable is not set")
 		os.Exit(1)
 	}
 	_, ok = os.LookupEnv("EMAIL_PORT")
 	if !ok {
-		fmt.Printf("EMAIL_PORT environmental variable is not set")
+		fmt.Printf("EMAIL_PORT environment variable is not set")
 		os.Exit(1)
 	}
 	_, ok = os.LookupEnv("EMAIL_USER")
 	if !ok {
-		fmt.Printf("EMAIL_USER environmental variable is not set")
+		fmt.Printf("EMAIL_USER environment variable is not set")
 		os.Exit(1)
 	}
 	_, ok = os.LookupEnv("EMAIL_PASSWORD")
 	if !ok {
-		fmt.Printf("EMAIL_PASSOWRD environmental variable is not set")
+		fmt.Printf("EMAIL_PASSOWRD environment variable is not set")
 		os.Exit(1)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -233,7 +233,7 @@ func Execute() {
 		os.Exit(1)
 	}
 
-	rootCmd.Flags().StringVarP(&fileFlag, "file", "p", "", "Path to input file")
+	rootCmd.Flags().StringVarP(&fileFlag, "file", "f", "", "Path to input file")
 	rootCmd.Flags().StringVarP(&templateFlag, "template", "t", "", "Path to custom html email template file")
 	err := rootCmd.Execute()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module ssmg
 
-go 1.21.4
+go 1.22.0
 
-require github.com/spf13/cobra v1.8.0
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df h1:n7WqCuqOuCbNr617RXOY0AWRXxgwEyPp2z+p0+hgMuE=
 gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=


### PR DESCRIPTION
- Changed the path arg to a flag
- Added a template flag to support custom HTML email templates
- Updates go version to 1.22.0
- Added env var checks 
- Increased version to 0.3,0